### PR TITLE
Moved the theme control block out of the is/isn't beta section.

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -64,9 +64,10 @@
   <%- include('header'); %>
     <a class="repl-link" href="/__repl">Edit on Replit</a>
 
+	<%- include('theme-control'); %>
+
 	<% if (beta == 1) {%>
 		<%- include('tags-header'); %>
-		<%- include('theme-control'); %>
 	<% } %>
 
 

--- a/views/post-page.ejs
+++ b/views/post-page.ejs
@@ -70,9 +70,7 @@
 <a class="repl-link" href="/__repl?fileName=posts/<%= post.url %>.md">Edit on Replit</a>
 
 <!-- dark theeme go brrr -->
-<% if (beta == 1) {%>
 <%- include('theme-control'); %>
-<% } %>
 
 <section class="categories-container-holder">
 


### PR DESCRIPTION
This PR removes the requirement for `?beta=1` to have theme switching/dark theme.