### PR TITLE
Pull Categories out of Beta

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -65,10 +65,7 @@
     <a class="repl-link" href="/__repl">Edit on Replit</a>
 
 	<%- include('theme-control'); %>
-
-	<% if (beta == 1) {%>
-		<%- include('tags-header'); %>
-	<% } %>
+	<%- include('tags-header'); %>
 
 
 	<!-- the removed code here is actually from my initial tags implementation. so much cleaner now lol -->
@@ -77,9 +74,6 @@
 	<% for (const post of posts) { %>
 		<%- include('post', { post, beta }); %>
     <% } %>
-
-	<!-- only show if on beta -->
-	<% if (beta == 1) {%>
 
 	<!-- only show if no posts are on screen (frontend js handles this since it handles showing and hiding posts) -->
 	<div id="noPostsNotifier" style="display: none;"><br><br><br><br><p style="color: var(--text-color);">Aw, there aren't any posts in this category yet 😔</p></div>
@@ -92,7 +86,6 @@
 			switchCategory(urlParams.get('category')) //dont ask
 		};
 	</script>
-	<% } %>
 
 	</div>
 >

--- a/views/post-page.ejs
+++ b/views/post-page.ejs
@@ -66,7 +66,7 @@
 <section class ="page_container">
 <%- include('header'); %>
 <!-- hardlinks bad smh -->
-<a class="back" href="/?beta=<%= beta %>"><span>← </span>Back to blog</a>
+<a class="back" href="/"><span>← </span>Back to blog</a>
 <a class="repl-link" href="/__repl?fileName=posts/<%= post.url %>.md">Edit on Replit</a>
 
 <!-- dark theeme go brrr -->
@@ -75,7 +75,6 @@
 <section class="categories-container-holder">
 
 <!-- all of this shows the categories bar at the top of a post -->
-<% if (beta == 1) {%>
 <div id="categories-container" class="categories-container"></div>
 </section>
 <script>
@@ -84,16 +83,14 @@
 	let finalInner = "";
 
 	categories.forEach((categoryName) => {
-		finalInner += `<p class="category-holder"><a href="/?category=${categoryName}&beta=1" id="category-${categoryName}" class="categories-child category">${categoryName}</a><p>`
+		finalInner += `<p class="category-holder"><a href="/?category=${categoryName}" id="category-${categoryName}" class="categories-child category">${categoryName}</a><p>`
 	})
 
 	document.getElementById('categories-container').innerHTML = finalInner;
 </script>
-<% } %>
 <!-- end of categories bar -->
 
-<!-- passing along if we're doing beta stuff -->
-<%- include('post', { post, beta }); %>
+<%- include('post', { post }); %>
 </section>
 
 <%- include('footer'); %>

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -8,7 +8,7 @@
 
 <article class="post-item<%= finalCategoriesClass %>">
 	<h1 class="post-title">
-		<a href="/<%= post.url%>?beta=<%= beta %>"><%= post.title %></a>
+		<a href="/<%= post.url%>"><%= post.title %></a>
 	</h1>
 	<h3 class="post-author">
 		<%= moment.utc(post.timestamp).format("ddd MMM D YYYY") %> by <%= post.author %>
@@ -17,7 +17,7 @@
 		<%- post.content %>
 	</div>
 	<% if (post.snipped) { %>
-		<a href="/<%= post.url %>?beta=<%= beta %>" class="read-more">
+		<a href="/<%= post.url %>" class="read-more">
 			Read more <span class ="arrow"> → </span>
 		</a>
 	<% } %>


### PR DESCRIPTION
1. Removes the requirement for `beta=1` to show the tags.
2. Stop appending `beta=0` or `beta=1` to urls.