### PR TITLE
Fix broken link to Student DPA

### DIFF
--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -6,7 +6,7 @@
       <a href="https://replit.com/site/privacy">Privacy</a>
       <a href="https://replit.com/site/subprocessors">Subprocessors</a>
       <a href="https://replit.com/site/dpa">DPA</a>
-      <a href="https://docs.replit.com/Teams/US_Student_DPA">US Student DPA</a>
+      <a href="https://docs.replit.com/teams-edu/us-student-dpa">US Student DPA</a>
     </div>
     <div class="footer_links">
       <h4>Replit</h4>


### PR DESCRIPTION
See https://replit.slack.com/archives/C030RJ2PRC7/p1694811652029139. 

Link was broken, now it's not. Corrected link to https://docs.replit.com/teams-edu/us-student-dpa

cc @stkenned 

